### PR TITLE
Use displayname in notification

### DIFF
--- a/Classes/Utility/RecordUtility.php
+++ b/Classes/Utility/RecordUtility.php
@@ -33,7 +33,7 @@ class RecordUtility
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('fe_users');
 
         $query = $queryBuilder
-            ->select('uid', 'username', 'email')
+            ->select('uid', 'username', 'name', 'email')
             ->from('fe_users')
             ->where(
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT))

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -10,7 +10,7 @@
 			</trans-unit>
 			<trans-unit id="plugin.subscriptions.description">
 				<source />
-				<target>Verwalten sie hier alle aktiv beobachteten Seiten.</target>
+				<target>Verwalten Sie hier alle aktiv beobachteten Seiten.</target>
 			</trans-unit>
 			<trans-unit id="plugin.subscriptions.action.subscribe">
 				<source />
@@ -30,7 +30,7 @@
 			</trans-unit>
 			<trans-unit id="plugin.favorites.description">
 				<source />
-				<target>Verwalten sie hier alle favorisierten Seiten.</target>
+				<target>Verwalten Sie hier alle favorisierten Seiten.</target>
 			</trans-unit>
 			<trans-unit id="plugin.favorites.action.save">
 				<source />
@@ -59,15 +59,15 @@
 			</trans-unit>
 			<trans-unit id="email.description">
 				<source />
-				<target><![CDATA[Die folgende(n) <strong>%s</strong> Änderung(en) bezüglich ihrer abonnierten Beobachtung(en) sind kürzlich aufgetreten:]]></target>
+				<target><![CDATA[Die folgende(n) <strong>%s</strong> Änderung(en) bezüglich Ihrer abonnierten Beobachtung(en) sind kürzlich aufgetreten:]]></target>
 			</trans-unit>
 			<trans-unit id="email.explanation">
 				<source />
-				<target><![CDATA[Diese Benachrichtigung wurde ihnen zugestellt aufgrund ihrer Beobachtungseinstellungen. Verwalten sie diese Einstellungen <a href="%s">hier</a>.]]></target>
+				<target><![CDATA[Diese Benachrichtigung wurde Ihnen zugestellt aufgrund Ihrer Beobachtungseinstellungen. Verwalten Sie diese Einstellungen <a href="%s">hier</a>.]]></target>
 			</trans-unit>
 			<trans-unit id="email.outro">
 				<source />
-				<target>Bleiben sie auf dem Laufenden.</target>
+				<target>Bleiben Sie auf dem Laufenden.</target>
 			</trans-unit>
 			<trans-unit id="email.update.type.1">
 				<source />

--- a/Resources/Private/Templates/Email/Notification.html
+++ b/Resources/Private/Templates/Email/Notification.html
@@ -15,7 +15,8 @@
         <f:translate key="email.header" extensionName="XimaTypo3PageSubscription"/>
     </h1>
     <p>
-        <f:translate key="email.intro" arguments="{0: feUser.username}" extensionName="XimaTypo3PageSubscription"/>
+        <f:variable name="displayname">{feUser.name ?: feUser.username}</f:variable>
+        <f:translate key="email.intro" arguments="{0: displayname}" extensionName="XimaTypo3PageSubscription"/>
     </p>
     <p>
         <f:format.raw>


### PR DESCRIPTION
The username may be a very technical name in LDAP environments.
If possible catch the the realname instead.

Also fix some typos.