### PR TITLE
fix: add exception handling and logging to crawler

### DIFF
--- a/Classes/Service/Crawler.php
+++ b/Classes/Service/Crawler.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3PageSubscription\Service;
 
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Bootstrap;
@@ -15,6 +18,10 @@ use Xima\XimaTypo3PageSubscription\Utility\UrlHelper;
 
 class Crawler
 {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
     /**
      * @throws \TYPO3\CMS\Core\Exception\SiteNotFoundException
      * @throws \TYPO3\CMS\Frontend\Typolink\UnableToLinkException
@@ -31,18 +38,26 @@ class Crawler
         $additionalParameter = (bool)(GeneralUtility::makeInstance(ExtensionConfiguration::class))->get(Configuration::EXT_KEY)['forceUncachedPageForCrawler'] ? '?no_cache=1' : '';
 
         $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
-        $response = $requestFactory->request(
-            $url . $additionalParameter,
-            'GET',
-            [
-                'headers' => [
-                    'X-PageSubscription-Crawler' => true,
-                    'Cache-Control' => 'no-cache, no-store, must-revalidate',
-                    'Pragma' => 'no-cache',
-                    'Expires' => '0',
-                ],
-            ]
-        );
+        try {
+            $response = $requestFactory->request(
+                $url . $additionalParameter,
+                'GET',
+                [
+                    'headers' => [
+                        'X-PageSubscription-Crawler' => true,
+                        'Cache-Control' => 'no-cache, no-store, must-revalidate',
+                        'Pragma' => 'no-cache',
+                        'Expires' => '0',
+                    ],
+                ]
+            );
+        } catch (ClientException $e) {
+            $this->logger->error('Client exception: ' . $e->getMessage(), ['url' => $url . $additionalParameter]);
+            return [];
+        } catch (ServerException $e) {
+            $this->logger->error('Server exception: ' . $e->getMessage(), ['url' => $url . $additionalParameter]);
+            return [];
+        }
 
         $content = $response->getBody()->getContents();
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -40,3 +40,11 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInter
 $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInterpreter'][\GeorgRinger\News\Domain\Model\NewsDefault::class] = \Xima\XimaTypo3PageSubscription\Interpreter\NewsInterpreter::class;
 $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInterpreter'][\GeorgRinger\News\Domain\Model\NewsInternal::class] = \Xima\XimaTypo3PageSubscription\Interpreter\NewsInterpreter::class;
 $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInterpreter'][\GeorgRinger\News\Domain\Model\NewsExternal::class] = \Xima\XimaTypo3PageSubscription\Interpreter\NewsInterpreter::class;
+
+$GLOBALS['TYPO3_CONF_VARS']['LOG']['Xima']['XimaTypo3PageSubscription']['writerConfiguration'] = [
+    \Psr\Log\LogLevel::ERROR => [
+        \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
+            'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/xima_typo3_page_subscription.log',
+        ],
+    ],
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -40,11 +40,3 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInter
 $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInterpreter'][\GeorgRinger\News\Domain\Model\NewsDefault::class] = \Xima\XimaTypo3PageSubscription\Interpreter\NewsInterpreter::class;
 $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInterpreter'][\GeorgRinger\News\Domain\Model\NewsInternal::class] = \Xima\XimaTypo3PageSubscription\Interpreter\NewsInterpreter::class;
 $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['registerInterpreter'][\GeorgRinger\News\Domain\Model\NewsExternal::class] = \Xima\XimaTypo3PageSubscription\Interpreter\NewsInterpreter::class;
-
-$GLOBALS['TYPO3_CONF_VARS']['LOG']['Xima']['XimaTypo3PageSubscription']['writerConfiguration'] = [
-    \Psr\Log\LogLevel::ERROR => [
-        \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-            'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/xima_typo3_page_subscription.log',
-        ],
-    ],
-];


### PR DESCRIPTION
Prevents the Crawler to throw exceptions and instead write them to log. Makes sure the scheduler task doesn't fail while checking pages for changes.