### PR TITLE
fix: allow linking restricted pages in UrlHelper::getAbsoluteUrl

### DIFF
--- a/Classes/Utility/UrlHelper.php
+++ b/Classes/Utility/UrlHelper.php
@@ -35,8 +35,9 @@ class UrlHelper
         self::createTypo3Request($site, $siteLanguage);
         $typolinkConfiguration = [
             'parameter' => $pageId,
+            'forceAbsoluteUrl' => true,
+            'linkAccessRestrictedPages' => true,
         ];
-        $typolinkConfiguration['forceAbsoluteUrl'] = true;
 
         return $linkFactory->create('', $typolinkConfiguration, $contentObjectRenderer)->getUrl();
     }


### PR DESCRIPTION
This fix prevents exceptions when checking subscriptions on access restricted pages.

However this fix doesn't cover the issue that the crawler is not able to find out if there are changes on these pages because he is not authenticated and therefor not able to fetch its contents.