### PR TITLE
feat: load PageSubscription.js via TypoScript and expose on window

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -6,10 +6,10 @@ pageWatchCheck {
   }
 }
 
-# page.includeJSFooterlibs {
-#    pageWatch = EXT:xima_typo3_page_subscription/Resources/Public/JavaScript/Listener.js
-#    pageWatch.type = module
-#}
+page.includeJSLibs {
+    ximaPageSubscription = EXT:xima_typo3_page_subscription/Resources/Public/JavaScript/PageSubscription.js
+    ximaPageSubscription.type = module
+}
 
 plugin.tx_ximatypo3pagesubscription {
     view {

--- a/README.md
+++ b/README.md
@@ -122,14 +122,12 @@ The technical implementation is based on the following concepts:
 <a name="javascript"></a>
 ### JavaScript
 
-Use the `PageSubscription` class to handle the subscription of pages in the frontend. Example below:
+Once the TypoScript is included, `PageSubscription` is available globally as `window.PageSubscription`. No import or bundler configuration is needed.
 
 ```javascript
-import PageSubscription from '../path/to/extension/xima_typo3_page_subscription/Resources/Public/JavaScript/PageSubscription.js';
-
 const toggleButton = document.querySelector('.toggle-subscription');
 toggleButton.addEventListener("click", async function(){
-    const data = await PageSubscription.toggle(this, PageSubscription.Type.Subscription, this.element.getAttribute('data-page-subscription-pid'));
+    const data = await window.PageSubscription.toggle(this, window.PageSubscription.Type.Subscription, this.getAttribute('data-page-subscription-pid'));
     if (data.result == true) {
         this.classList.add('subscribed');
     } else {
@@ -137,6 +135,8 @@ toggleButton.addEventListener("click", async function(){
     }
 });
 ```
+
+If you are using a JavaScript bundler and prefer a module import, the file also ships a standard ES module export:
 
 <a name="viewhelper"></a>
 ### ViewHelper

--- a/Resources/Public/JavaScript/PageSubscription.js
+++ b/Resources/Public/JavaScript/PageSubscription.js
@@ -46,4 +46,6 @@ class PageSubscription {
   }
 }
 
-export default new PageSubscription();
+const pageSubscription = new PageSubscription();
+export default pageSubscription;
+window.PageSubscription = pageSubscription;


### PR DESCRIPTION
- Register window.PageSubscription in PageSubscription.js so consumers can use the API without a bundler or manual import
- Load PageSubscription.js via page.includeJSLibs in the frontend so it is available before any dependent scripts execute
- Update README to document the window-based usage and mention the ES module export as an alternative for bundler setups